### PR TITLE
Add `{save,restore}_checkpoint` to `PartialPaths` to rewind the arena allocator pointers

### DIFF
--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -188,6 +188,10 @@ impl<T> Arena<T> {
         self.items.truncate(1);
     }
 
+    pub(crate) fn truncate(&mut self, new_len: usize) {
+        self.items.truncate(new_len);
+    }
+
     /// Adds a new instance to this arena, returning a stable handle to it.
     ///
     /// Note that we do not deduplicate instances of `T` in any way.  If you add two instances that

--- a/stack-graphs/src/arena.rs
+++ b/stack-graphs/src/arena.rs
@@ -188,6 +188,7 @@ impl<T> Arena<T> {
         self.items.truncate(1);
     }
 
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
     pub(crate) fn truncate(&mut self, new_len: usize) {
         self.items.truncate(new_len);
     }

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2632,6 +2632,7 @@ impl PartialPaths {
         self.partial_path_edges.clear();
     }
 
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
     pub fn save_checkpoint(&self) -> PartialPathsCheckpoint {
         PartialPathsCheckpoint {
             partial_symbol_stacks_len: self.partial_symbol_stacks.len(),
@@ -2640,6 +2641,7 @@ impl PartialPaths {
         }
     }
 
+    // __NOMIC_FOUNDATION_FORK__ (added this function)
     pub fn restore_checkpoint(&mut self, checkpoint: PartialPathsCheckpoint) {
         self.partial_symbol_stacks
             .truncate(checkpoint.partial_symbol_stacks_len);
@@ -2650,6 +2652,7 @@ impl PartialPaths {
     }
 }
 
+// __NOMIC_FOUNDATION_FORK__ (added this struct)
 pub struct PartialPathsCheckpoint {
     partial_symbol_stacks_len: usize,
     partial_scope_stacks_len: usize,

--- a/stack-graphs/src/partial.rs
+++ b/stack-graphs/src/partial.rs
@@ -2631,4 +2631,27 @@ impl PartialPaths {
         self.partial_scope_stacks.clear();
         self.partial_path_edges.clear();
     }
+
+    pub fn save_checkpoint(&self) -> PartialPathsCheckpoint {
+        PartialPathsCheckpoint {
+            partial_symbol_stacks_len: self.partial_symbol_stacks.len(),
+            partial_scope_stacks_len: self.partial_scope_stacks.len(),
+            partial_path_edges_len: self.partial_path_edges.len(),
+        }
+    }
+
+    pub fn restore_checkpoint(&mut self, checkpoint: PartialPathsCheckpoint) {
+        self.partial_symbol_stacks
+            .truncate(checkpoint.partial_symbol_stacks_len);
+        self.partial_scope_stacks
+            .truncate(checkpoint.partial_scope_stacks_len);
+        self.partial_path_edges
+            .truncate(checkpoint.partial_path_edges_len);
+    }
+}
+
+pub struct PartialPathsCheckpoint {
+    partial_symbol_stacks_len: usize,
+    partial_scope_stacks_len: usize,
+    partial_path_edges_len: usize,
 }


### PR DESCRIPTION
This allows us to use `PartialPaths` for a database of pre-computed minimal partial paths for resolution and reuse it to resolve many references without increasing the memory used.
